### PR TITLE
chore: add .cs to generic file extensions

### DIFF
--- a/config/default_config.yaml
+++ b/config/default_config.yaml
@@ -158,5 +158,6 @@ genericCodeFileExtensions:
   - c
   - h
   - hpp
+  - cs
 disableOutputColors: false
 verbose: false


### PR DESCRIPTION
This PR adds cs files to the generic file extensions of the default config. 
This file extension is commonly used by C# code.
